### PR TITLE
feat: add Fly.io deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.env
+.env.*
+.worktrees
+test
+docs
+.git
+.gitignore
+screenshot.png
+test-output.txt
+tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY src/ ./src/
+COPY config.json ./
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "src/server.js"]

--- a/README.md
+++ b/README.md
@@ -175,6 +175,43 @@ Automated sync is a v2 consideration.
 - Check bot has `canvases:write` scope
 - Verify bot is member of channel
 
+## Deployment (Fly.io)
+
+### First-time setup
+
+1. Install the Fly CLI: https://fly.io/docs/hands-on/install-flyctl/
+2. Authenticate: `fly auth login`
+3. Create the app and volume:
+   ```bash
+   fly apps create slon-calendar-bot
+   fly volumes create calendar_bot_data --region fra --size 1
+   ```
+4. Set secrets:
+   ```bash
+   fly secrets set SLACK_BOT_TOKEN=xoxb-...
+   fly secrets set CALDAV_PASSWORD=your-nextcloud-app-password
+   ```
+5. Deploy:
+   ```bash
+   fly deploy
+   ```
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `SLACK_BOT_TOKEN` | Yes | Slack bot token (`xoxb-...`). Set via `fly secrets set`. |
+| `CALDAV_PASSWORD` | Yes | Nextcloud app password for CalDAV. Set via `fly secrets set`. |
+| `DATA_DIR` | Yes | Directory for SQLite DB. Set to `/data` in `fly.toml`. |
+| `PORT` | No | HTTP port (default: `8080`). Set in `fly.toml`. |
+| `DRY_RUN` | No | If `true`, routes Slack messages to `error_channel` instead of posting. |
+| `CONFIG_FILE` | No | Path to `config.json` (default: `./config.json`). |
+| `CACHE_DIR` | No | Deprecated. Used only to migrate legacy flat-file cache to SQLite on first boot. |
+
+### Health check
+
+The server exposes `GET /health` → `{"status":"ok"}` (HTTP 200). Fly.io uses this for readiness checks.
+
 ## License
 
 MIT

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,31 @@
+app = "slon-calendar-bot"
+primary_region = "fra"
+
+[build]
+
+[env]
+  DATA_DIR = "/data"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/health"
+    timeout = "5s"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[[mounts]]
+  source = "calendar_bot_data"
+  destination = "/data"

--- a/src/server.js
+++ b/src/server.js
@@ -108,9 +108,10 @@ async function start() {
   function shutdown() {
     console.log('Shutting down — stopping cron jobs');
     for (const job of jobs) job.stop();
-    httpServer.close();
-    db.close();
-    process.exit(0);
+    httpServer.close(() => {
+      db.close();
+      process.exit(0);
+    });
   }
 
   process.on('SIGTERM', shutdown);

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,4 @@
+const http = require('node:http');
 const path = require('node:path');
 const cron = require('node-cron');
 const { loadConfig } = require('./config.js');
@@ -37,7 +38,7 @@ function scheduleStringToCron(str) {
 }
 
 async function start() {
-  const config = await loadConfig();
+  const config = await loadConfig(process.env.CONFIG_FILE);
 
   const dataDir = process.env.DATA_DIR;
   if (!dataDir) throw new Error('DATA_DIR environment variable not set');
@@ -90,9 +91,24 @@ async function start() {
     }
   }));
 
+  const port = parseInt(process.env.PORT || '8080', 10);
+  const httpServer = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  httpServer.listen(port, () => {
+    console.log(`HTTP server listening on port ${port}`);
+  });
+
   function shutdown() {
     console.log('Shutting down — stopping cron jobs');
     for (const job of jobs) job.stop();
+    httpServer.close();
     db.close();
     process.exit(0);
   }


### PR DESCRIPTION
## Summary

- Adds `GET /health` endpoint to `src/server.js` (node:http, no new deps) — Fly.io uses this for readiness checks
- Adds `Dockerfile` (Node 20 Alpine, production deps only, copies `config.json`)
- Adds `fly.toml` (app `slon-calendar-bot`, fra region, `/data` volume mount, health check every 30s, 256mb shared VM)
- Adds deployment section to README documenting all env vars and first-time setup steps

## Test Plan

### Health endpoint (local, no Fly account needed)

```bash
# 1. Start the server (real DATA_DIR and config required)
DATA_DIR=/tmp node src/server.js

# 2. In another terminal
curl -s http://localhost:8080/health
# Expected: {"status":"ok"}

# 3. Confirm non-health routes return 404
curl -o /dev/null -w "%{http_code}" http://localhost:8080/other
# Expected: 404
```

### Docker build (needs Docker)

```bash
docker build -t calendar-slack-bot .
docker run --rm \
  -e DATA_DIR=/tmp \
  -e SLACK_BOT_TOKEN=xoxb-placeholder \
  -e CALDAV_PASSWORD=placeholder \
  -p 8080:8080 \
  calendar-slack-bot
# Server should start and log cron job registrations
curl -s http://localhost:8080/health
# Expected: {"status":"ok"}
```

### Fly.io deploy (needs fly CLI + org access)

```bash
fly apps create slon-calendar-bot        # one-time
fly volumes create calendar_bot_data --region fra --size 1  # one-time
fly secrets set SLACK_BOT_TOKEN=xoxb-...
fly secrets set CALDAV_PASSWORD=...
fly deploy
fly status  # machine should be running
curl https://slon-calendar-bot.fly.dev/health
# Expected: {"status":"ok"}
```

refs: #24